### PR TITLE
Fix error in edit users

### DIFF
--- a/frontend/assets/ts/classes/Users/Edit.ts
+++ b/frontend/assets/ts/classes/Users/Edit.ts
@@ -93,7 +93,7 @@ export default class Edit {
 		})
 	}
 	protected static submitHandler(form: HTMLFormElement): void {
-		const selectedPermissions = Permissions.getSelectedPermissionsFromFancytree(Edit.$permissions);
+		const selectedPermissions = Edit.canEditPermissions ? Permissions.getSelectedPermissionsFromFancytree(Edit.$permissions) : [];
 		const getFormData = (formElement: HTMLFormElement): FormData => {
 			const formData = new FormData(formElement);
 			if (selectedPermissions.length) {


### PR DESCRIPTION
## Problem
Got Javascript error about Jquery Fancytree plugin in submit edit user and changes is not sended to Server if fancytree is not loaded. Fancytree plugin used for show user current permissions and customizing them.
If the user that open edit user page has not access to customize users permissions so fancytree is not loaded but in submit edit form there is an error about using this plugin.

## Solution
Check fancytree is loaded before get selected permissions.

### Steps
In `Users Edit ts file` before get selected permissions from fancytree check the editor user has access to change permissions first to ensure fancytree plugin is loaded in the page and then get permissions. 